### PR TITLE
Add io.Writer helper for rope

### DIFF
--- a/internal/rope/rope.go
+++ b/internal/rope/rope.go
@@ -1,5 +1,7 @@
 package rope
 
+import "io"
+
 // Node represents a node in the rope tree. A node is either an internal
 // node with left/right children, or a leaf node that holds a substring.
 type Node struct {
@@ -88,6 +90,28 @@ type binaryRope struct {
 // New creates a new Rope containing the provided string.
 func New(s string) Rope {
 	return &binaryRope{root: leaf(s)}
+}
+
+// Read consumes all data from r and returns a new Rope containing it.
+// Any error encountered while reading is returned.
+func Read(r io.Reader) (Rope, error) {
+	if r == nil {
+		return &binaryRope{}, nil
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	return New(string(data)), nil
+}
+
+// Write writes the contents of rp to w. It returns the number of bytes written
+// and any error encountered during the write.
+func Write(w io.Writer, rp Rope) (int, error) {
+	if w == nil || rp == nil {
+		return 0, nil
+	}
+	return io.WriteString(w, rp.String())
 }
 
 // Len returns the number of bytes stored in the rope.

--- a/internal/rope/rope_test.go
+++ b/internal/rope/rope_test.go
@@ -1,6 +1,10 @@
 package rope
 
-import "testing"
+import (
+	"errors"
+	"strings"
+	"testing"
+)
 
 func TestNewLenString(t *testing.T) {
 	r := New("hello world")
@@ -9,6 +13,57 @@ func TestNewLenString(t *testing.T) {
 	}
 	if got := r.String(); got != "hello world" {
 		t.Fatalf("expected %q got %q", "hello world", got)
+	}
+}
+
+func TestRead(t *testing.T) {
+	br, err := Read(strings.NewReader("hello world"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := br.String(); got != "hello world" {
+		t.Fatalf("expected %q got %q", "hello world", got)
+	}
+	if br.Len() != len("hello world") {
+		t.Fatalf("expected length %d got %d", len("hello world"), br.Len())
+	}
+}
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) {
+	return 0, errors.New("fail")
+}
+
+func TestReadError(t *testing.T) {
+	if _, err := Read(errReader{}); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestWrite(t *testing.T) {
+	r := New("hello world")
+	var buf strings.Builder
+	n, err := Write(&buf, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len("hello world") {
+		t.Fatalf("expected %d bytes written got %d", len("hello world"), n)
+	}
+	if got := buf.String(); got != "hello world" {
+		t.Fatalf("expected %q got %q", "hello world", got)
+	}
+}
+
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) { return 0, errors.New("fail") }
+
+func TestWriteError(t *testing.T) {
+	r := New("hello")
+	if _, err := Write(errWriter{}, r); err == nil {
+		t.Fatalf("expected error")
 	}
 }
 


### PR DESCRIPTION
## Summary
- introduce `Write` to output a rope's data to an `io.Writer`
- test successful writes and writer error handling

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684ef6c1a2588328bde60bd2f0e08e63