### PR TITLE
Add page up/down scrolling

### DIFF
--- a/internal/app/core.go
+++ b/internal/app/core.go
@@ -181,6 +181,18 @@ func (a *app) Run(screen tcell.Screen) {
 					a.views[0].SetTopLeft(top, left)
 					a.views[0].SetCursor(row, col)
 				}
+			} else if ev.Key() == tcell.KeyPgUp || ev.Key() == tcell.KeyPgDn {
+				if len(a.views) > 0 {
+					_, height := screen.Size()
+					top, left := a.views[0].TopLeft()
+					page := height - 1
+					if ev.Key() == tcell.KeyPgUp {
+						top = max(0, top-page)
+					} else {
+						top = top + page
+					}
+					a.views[0].SetTopLeft(top, left)
+				}
 			}
 		case *tcell.EventMouse:
 			x, y := ev.Position()
@@ -189,6 +201,12 @@ func (a *app) Run(screen tcell.Screen) {
 			case tcell.Button1:
 				top, left := a.views[0].TopLeft()
 				a.views[0].SetCursor(top+y, left+x)
+			case tcell.WheelUp:
+				top, left := a.views[0].TopLeft()
+				a.views[0].SetTopLeft(max(0, top-1), left)
+			case tcell.WheelDown:
+				top, left := a.views[0].TopLeft()
+				a.views[0].SetTopLeft(top+1, left)
 			}
 		}
 


### PR DESCRIPTION
## Summary
- handle tcell.WheelUp and tcell.WheelDown in event loop
- scroll by one page on PgUp/PgDn keys

## Testing
- `go test ./...` *(fails: github.com/gdamore/tcell/v2 not downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68507ccbf824832886500e3f2463968c