### PR TITLE
Refactor view to use viewState

### DIFF
--- a/internal/app/buffer.go
+++ b/internal/app/buffer.go
@@ -9,6 +9,8 @@ type Buffer interface {
 	GetFilename() string
 	Contents() rope.Rope
 	IsDirty() bool
+	// Insert returns a new Buffer with text inserted at the specified index.
+	Insert(idx int, text string) Buffer
 }
 
 type buffer struct {
@@ -27,6 +29,24 @@ func (b *buffer) Contents() rope.Rope {
 
 func (b *buffer) IsDirty() bool {
 	return b.dirty
+}
+
+func (b *buffer) Insert(idx int, text string) Buffer {
+	if b == nil {
+		return nil
+	}
+	if idx < 0 {
+		idx = 0
+	}
+	if idx > b.contents.Len() {
+		idx = b.contents.Len()
+	}
+	nb := &buffer{
+		filename: b.filename,
+		contents: b.contents.Insert(idx, text),
+		dirty:    true,
+	}
+	return nb
 }
 
 func NewBuffer(filename string) (Buffer, error) {

--- a/internal/app/buffer.go
+++ b/internal/app/buffer.go
@@ -32,9 +32,6 @@ func (b *buffer) IsDirty() bool {
 }
 
 func (b *buffer) Insert(idx int, text string) Buffer {
-	if b == nil {
-		return nil
-	}
 	if idx < 0 {
 		idx = 0
 	}

--- a/internal/app/core.go
+++ b/internal/app/core.go
@@ -181,6 +181,28 @@ func (a *app) Run(screen tcell.Screen) {
 					a.views[0].SetTopLeft(top, left)
 					a.views[0].SetCursor(row, col)
 				}
+			} else if ev.Key() == tcell.KeyRune {
+				if len(a.views) > 0 {
+					a.views[0].InsertRune(ev.Rune())
+
+					width, height := screen.Size()
+					top, left := a.views[0].TopLeft()
+					row, col := a.views[0].Cursor()
+
+					if row < top {
+						top = row
+					} else if row >= top+height-1 {
+						top = row - height + 2
+					}
+
+					if col < left {
+						left = col
+					} else if col >= left+width-1 {
+						left = col - (width - 2)
+					}
+
+					a.views[0].SetTopLeft(top, left)
+				}
 			} else if ev.Key() == tcell.KeyPgUp || ev.Key() == tcell.KeyPgDn {
 				if len(a.views) > 0 {
 					_, height := screen.Size()

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -13,7 +13,7 @@ type View interface {
 	SetCursor(row, col int)
 }
 
-type view struct {
+type viewState struct {
 	buffer    Buffer
 	top       int
 	left      int
@@ -21,34 +21,58 @@ type view struct {
 	cursorCol int
 }
 
+type view struct {
+	states []viewState
+}
+
 func (v *view) Buffer() Buffer {
-	return v.buffer
+	return v.states[0].buffer
 }
 
 func (v *view) TopLeft() (int, int) {
-	return v.top, v.left
+	if len(v.states) == 0 {
+		return 0, 0
+	}
+	s := v.states[0]
+	return s.top, s.left
 }
 
 func (v *view) SetTopLeft(top, left int) {
-	v.top = max(0, top)
-	v.left = max(0, left)
+	if len(v.states) == 0 {
+		return
+	}
+	s := &v.states[0]
+	s.top = max(0, top)
+	s.left = max(0, left)
 }
 
 func (v *view) Cursor() (int, int) {
-	return v.cursorRow, v.cursorCol
+	if len(v.states) == 0 {
+		return 0, 0
+	}
+	s := v.states[0]
+	return s.cursorRow, s.cursorCol
 }
 
 func (v *view) SetCursor(row, col int) {
-	v.cursorRow = max(0, row)
-	v.cursorCol = max(0, col)
+	if len(v.states) == 0 {
+		return
+	}
+	s := &v.states[0]
+	s.cursorRow = max(0, row)
+	s.cursorCol = max(0, col)
 }
 
 func NewView(buffer Buffer) View {
 	return &view{
-		buffer:    buffer,
-		top:       0,
-		left:      0,
-		cursorRow: 0,
-		cursorCol: 0,
+		states: []viewState{
+			{
+				buffer:    buffer,
+				top:       0,
+				left:      0,
+				cursorRow: 0,
+				cursorCol: 0,
+			},
+		},
 	}
 }


### PR DESCRIPTION
## Summary
- introduce a `viewState` structure
- store a slice of `viewState` inside `view`
- access the first `viewState` when working with buffer, cursor and viewport

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go build ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685085b0e888832892f3c195b4e79ac5