### PR TITLE
Add delete and backspace support

### DIFF
--- a/internal/app/buffer.go
+++ b/internal/app/buffer.go
@@ -15,6 +15,8 @@ type Buffer interface {
 	// Returns a new Buffer with text inserted at the specified index.
 	// Insert returns a new Buffer with text inserted at the specified index.
 	Insert(idx int, text string) Buffer
+	// Delete returns a new Buffer with the specified range removed.
+	Delete(start, end int) Buffer
 }
 
 type buffer struct {
@@ -45,6 +47,24 @@ func (b *buffer) Insert(idx int, text string) Buffer {
 	nb := &buffer{
 		filename: b.filename,
 		contents: b.contents.Insert(idx, text),
+		dirty:    true,
+	}
+	return nb
+}
+
+func (b *buffer) Delete(start, end int) Buffer {
+	if start < 0 {
+		start = 0
+	}
+	if end > b.contents.Len() {
+		end = b.contents.Len()
+	}
+	if start > end {
+		start, end = end, start
+	}
+	nb := &buffer{
+		filename: b.filename,
+		contents: b.contents.Delete(start, end),
 		dirty:    true,
 	}
 	return nb

--- a/internal/app/buffer_test.go
+++ b/internal/app/buffer_test.go
@@ -1,0 +1,53 @@
+package app
+
+import "testing"
+
+func TestBufferDelete(t *testing.T) {
+	b, err := NewBuffer("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	b = b.Insert(0, "hello")
+	b = b.Delete(1, 2) // remove 'e'
+	got := b.Contents().String()
+	if got != "hllo" {
+		t.Fatalf("expected %q got %q", "hllo", got)
+	}
+}
+
+func TestBufferInsert(t *testing.T) {
+	b, err := NewBuffer("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// inserting into empty buffer
+	b2 := b.Insert(0, "world")
+	if got := b.Contents().String(); got != "" {
+		t.Fatalf("original buffer modified: %q", got)
+	}
+	if got := b2.Contents().String(); got != "world" {
+		t.Fatalf("expected %q got %q", "world", got)
+	}
+	if !b2.IsDirty() {
+		t.Fatalf("expected dirty buffer after insert")
+	}
+
+	// insert at beginning
+	b3 := b2.Insert(0, "hello ")
+	if got := b3.Contents().String(); got != "hello world" {
+		t.Fatalf("expected %q got %q", "hello world", got)
+	}
+
+	// insert beyond end should append
+	b4 := b3.Insert(100, " end")
+	if got := b4.Contents().String(); got != "hello world end" {
+		t.Fatalf("expected %q got %q", "hello world end", got)
+	}
+
+	// insert with negative index should prepend
+	b5 := b3.Insert(-10, "start ")
+	if got := b5.Contents().String(); got != "start hello world" {
+		t.Fatalf("expected %q got %q", "start hello world", got)
+	}
+}

--- a/internal/app/core.go
+++ b/internal/app/core.go
@@ -181,6 +181,50 @@ func (a *app) Run(screen tcell.Screen) {
 					a.views[0].SetTopLeft(top, left)
 					a.views[0].SetCursor(row, col)
 				}
+			} else if ev.Key() == tcell.KeyBackspace || ev.Key() == tcell.KeyBackspace2 {
+				if len(a.views) > 0 {
+					a.views[0].DeleteRune(false)
+
+					width, height := screen.Size()
+					top, left := a.views[0].TopLeft()
+					row, col := a.views[0].Cursor()
+
+					if row < top {
+						top = row
+					} else if row >= top+height-1 {
+						top = row - height + 2
+					}
+
+					if col < left {
+						left = col
+					} else if col >= left+width-1 {
+						left = col - (width - 2)
+					}
+
+					a.views[0].SetTopLeft(top, left)
+				}
+			} else if ev.Key() == tcell.KeyDelete {
+				if len(a.views) > 0 {
+					a.views[0].DeleteRune(true)
+
+					width, height := screen.Size()
+					top, left := a.views[0].TopLeft()
+					row, col := a.views[0].Cursor()
+
+					if row < top {
+						top = row
+					} else if row >= top+height-1 {
+						top = row - height + 2
+					}
+
+					if col < left {
+						left = col
+					} else if col >= left+width-1 {
+						left = col - (width - 2)
+					}
+
+					a.views[0].SetTopLeft(top, left)
+				}
 			} else if ev.Key() == tcell.KeyRune {
 				if len(a.views) > 0 {
 					a.views[0].InsertRune(ev.Rune())

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -15,6 +15,10 @@ type View interface {
 	SetCursor(row, col int)
 	// InsertRune inserts a rune into the buffer at the cursor position.
 	InsertRune(r rune)
+	// DeleteRune deletes a rune. When forward is true it deletes the rune
+	// under the cursor (Delete key behaviour). Otherwise it deletes the
+	// rune before the cursor (Backspace behaviour).
+	DeleteRune(forward bool)
 }
 
 type viewState struct {
@@ -109,6 +113,74 @@ func (v *view) InsertRune(r rune) {
 	} else {
 		newCol++
 	}
+
+	newState := viewState{
+		buffer:    newBuf,
+		top:       curr.top,
+		left:      curr.left,
+		cursorRow: newRow,
+		cursorCol: newCol,
+	}
+	v.states = append([]viewState{newState}, v.states...)
+}
+
+func (v *view) DeleteRune(forward bool) {
+	if len(v.states) == 0 {
+		return
+	}
+
+	curr := v.states[0]
+	idx := bufferIndexAt(curr.buffer.Contents(), curr.cursorRow, curr.cursorCol)
+
+	start := idx
+	end := idx
+	var ch byte
+	var ok bool
+	newRow := curr.cursorRow
+	newCol := curr.cursorCol
+
+	if forward {
+		ch, ok = curr.buffer.Contents().Index(idx)
+		if !ok {
+			return
+		}
+		start = idx
+		end = idx + 1
+	} else {
+		if idx == 0 {
+			return
+		}
+		ch, _ = curr.buffer.Contents().Index(idx - 1)
+		start = idx - 1
+		end = idx
+		if ch == '\n' {
+			newRow--
+			colCount := 0
+			scanIdx := start - 1
+			for scanIdx >= 0 {
+				b, ok := curr.buffer.Contents().Index(scanIdx)
+				if !ok {
+					break
+				}
+				if b == '\n' {
+					break
+				}
+				colCount++
+				scanIdx--
+			}
+			newCol = colCount
+		} else {
+			newCol--
+		}
+		if newRow < 0 {
+			newRow = 0
+		}
+		if newCol < 0 {
+			newCol = 0
+		}
+	}
+
+	newBuf := curr.buffer.Delete(start, end)
 
 	newState := viewState{
 		buffer:    newBuf,


### PR DESCRIPTION
## Summary
- support deleting buffer ranges
- implement forward and backward rune deletion in views
- wire up delete and backspace keys in the event loop
- add tests for Buffer.Delete and Buffer.Insert
- merge forward/backward delete methods into one

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68508d12e3cc8328aafed46d2897f4eb