### PR TITLE
Add StatusBar error display

### DIFF
--- a/internal/app/core.go
+++ b/internal/app/core.go
@@ -144,7 +144,9 @@ eventLoop:
 			} else if ev.Key() == tcell.KeyCtrlS {
 				if len(a.views) > 0 {
 					if err := a.views[a.currentView].Buffer().Save(); err != nil {
-						// TODO: handle error properly (status bar?)
+						if a.statusBar != nil {
+							a.statusBar.Errorf(screen, "Error saving file: %v", err)
+						}
 					}
 				}
 			} else if ev.Key() == tcell.KeyCtrlO {
@@ -152,7 +154,9 @@ eventLoop:
 					filename, ok := a.statusBar.Input(screen, "Open file: ")
 					if ok && filename != "" {
 						if err := a.OpenFile(filename); err != nil {
-							// TODO: handle error properly (status bar?)
+							if a.statusBar != nil {
+								a.statusBar.Errorf(screen, "Error opening file: %v", err)
+							}
 						}
 					}
 				}

--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -13,6 +13,10 @@ type StatusBar interface {
 	// Input displays a prompt on the status bar and returns the entered value.
 	// The boolean return is false if the prompt was cancelled with Esc.
 	Input(s tcell.Screen, prompt string) (string, bool)
+	// Error displays an error message on the status bar until a key is pressed.
+	Error(s tcell.Screen, msg string)
+	// Errorf formats the error message and displays it until a key is pressed.
+	Errorf(s tcell.Screen, format string, args ...interface{})
 }
 
 type statusBar struct{}
@@ -79,4 +83,29 @@ func (sb *statusBar) Draw(s tcell.Screen, v View) {
 	width, height := s.Size()
 	drawText(s, 0, height-1, width-1, height-1, tcell.StyleDefault.Foreground(tcell.ColorWhite), filename+dirty)
 	drawText(s, len(filename)+len(dirty), height-1, width-1, height-1, tcell.StyleDefault.Foreground(tcell.ColorWhite), cursor)
+}
+
+// Error displays an error message on the status bar until a key is pressed.
+func (sb *statusBar) Error(s tcell.Screen, msg string) {
+	for {
+		width, height := s.Size()
+		for x := 0; x < width; x++ {
+			s.SetContent(x, height-1, ' ', nil, tcell.StyleDefault)
+		}
+		drawText(s, 0, height-1, width-1, height-1, tcell.StyleDefault.Foreground(tcell.ColorRed), msg)
+		s.Show()
+
+		ev := s.PollEvent()
+		switch ev.(type) {
+		case *tcell.EventKey, *tcell.EventMouse:
+			return
+		case *tcell.EventResize:
+			s.Sync()
+		}
+	}
+}
+
+// Errorf formats the error message and displays it until a key is pressed.
+func (sb *statusBar) Errorf(s tcell.Screen, format string, args ...interface{}) {
+	sb.Error(s, fmt.Sprintf(format, args...))
 }


### PR DESCRIPTION
## Summary
- support displaying error messages on the status bar
- use the error display when saving or opening files fails
- add formatted error helper

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6850ae17eadc83289d1fb44ab793b564