### PR TITLE
Improve keybinding lookup and naming

### DIFF
--- a/cmd/tked/main.go
+++ b/cmd/tked/main.go
@@ -14,7 +14,7 @@ func main() {
 
 	app.RegisterCommands()
 
-	app, err := app.NewApp()
+	application, err := app.NewApp()
 	if err != nil {
 		log.Fatalf("Failed to create app: %v", err)
 	}
@@ -22,7 +22,7 @@ func main() {
 	// Is there a file to open?
 	if flag.NArg() > 0 {
 		filename := flag.Arg(0)
-		err = app.OpenFile(filename)
+		err = application.OpenFile(filename)
 		if err != nil {
 			log.Fatalf("Failed to open file: %v", err)
 		}
@@ -49,5 +49,5 @@ func main() {
 	}
 	defer quit()
 
-	app.Run(screen)
+	application.Run(screen)
 }

--- a/internal/app/keybinding.go
+++ b/internal/app/keybinding.go
@@ -8,36 +8,42 @@ type KeyBinding struct {
 	Command Command
 }
 
-type KeyBindings struct {
-	KeyBindings []KeyBinding
+type keyCombo struct {
+	key tcell.Key
+	mod tcell.ModMask
 }
 
-func (k *KeyBindings) GetCommandForKey(key tcell.Key, mod tcell.ModMask) Command {
-	for _, binding := range k.KeyBindings {
-		if binding.Key == key && binding.Mod == mod {
-			return binding.Command
-		}
+type KeyBindings struct {
+	bindings map[keyCombo]Command
+}
+
+func NewKeyBindings(b []KeyBinding) KeyBindings {
+	kb := KeyBindings{bindings: make(map[keyCombo]Command, len(b))}
+	for _, binding := range b {
+		kb.bindings[keyCombo{binding.Key, binding.Mod}] = binding.Command
 	}
-	return nil
+	return kb
+}
+
+func (k KeyBindings) GetCommandForKey(key tcell.Key, mod tcell.ModMask) Command {
+	return k.bindings[keyCombo{key, mod}]
 }
 
 func DefaultKeyBindings() KeyBindings {
-	return KeyBindings{
-		KeyBindings: []KeyBinding{
-			{tcell.KeyEscape, tcell.ModNone, GetCommand("exit")},
-			{tcell.KeyCtrlZ, tcell.ModCtrl, GetCommand("undo")},
-			{tcell.KeyCtrlR, tcell.ModCtrl, GetCommand("redo")},
-			{tcell.KeyCtrlS, tcell.ModCtrl, GetCommand("save")},
-			{tcell.KeyCtrlO, tcell.ModCtrl, GetCommand("open")},
-			{tcell.KeyUp, tcell.ModNone, GetCommand("up")},
-			{tcell.KeyDown, tcell.ModNone, GetCommand("down")},
-			{tcell.KeyLeft, tcell.ModNone, GetCommand("left")},
-			{tcell.KeyRight, tcell.ModNone, GetCommand("right")},
-			{tcell.KeyBackspace, tcell.ModNone, GetCommand("backspace")},
-			{tcell.KeyBackspace2, tcell.ModNone, GetCommand("backspace")},
-			{tcell.KeyDelete, tcell.ModNone, GetCommand("delete")},
-			{tcell.KeyPgUp, tcell.ModNone, GetCommand("pageup")},
-			{tcell.KeyPgDn, tcell.ModNone, GetCommand("pagedown")},
-		},
-	}
+	return NewKeyBindings([]KeyBinding{
+		{tcell.KeyEscape, tcell.ModNone, GetCommand("exit")},
+		{tcell.KeyCtrlZ, tcell.ModCtrl, GetCommand("undo")},
+		{tcell.KeyCtrlR, tcell.ModCtrl, GetCommand("redo")},
+		{tcell.KeyCtrlS, tcell.ModCtrl, GetCommand("save")},
+		{tcell.KeyCtrlO, tcell.ModCtrl, GetCommand("open")},
+		{tcell.KeyUp, tcell.ModNone, GetCommand("up")},
+		{tcell.KeyDown, tcell.ModNone, GetCommand("down")},
+		{tcell.KeyLeft, tcell.ModNone, GetCommand("left")},
+		{tcell.KeyRight, tcell.ModNone, GetCommand("right")},
+		{tcell.KeyBackspace, tcell.ModNone, GetCommand("backspace")},
+		{tcell.KeyBackspace2, tcell.ModNone, GetCommand("backspace")},
+		{tcell.KeyDelete, tcell.ModNone, GetCommand("delete")},
+		{tcell.KeyPgUp, tcell.ModNone, GetCommand("pageup")},
+		{tcell.KeyPgDn, tcell.ModNone, GetCommand("pagedown")},
+	})
 }


### PR DESCRIPTION
## Summary
- avoid variable shadowing in main
- use a map for key bindings for efficient lookup

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6851d50ca7708328bc212cd2f019552a