### PR TITLE
Add config load/save with keyBindings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,12 @@ module tked
 go 1.24.4
 
 require (
-	github.com/gdamore/encoding v1.0.1 // indirect
 	github.com/gdamore/tcell/v2 v2.8.1
+	github.com/pelletier/go-toml/v2 v2.2.4
+)
+
+require (
+	github.com/gdamore/encoding v1.0.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/rivo/uniseg v0.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
+github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.3 h1:utMvzDsuh3suAEnhH0RdHmoPbU648o6CvXxTx4SBMOw=
 github.com/rivo/uniseg v0.4.3/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/internal/app/core.go
+++ b/internal/app/core.go
@@ -20,7 +20,6 @@ type app struct {
 	statusBar   StatusBar
 	currentView int
 	settings    Settings
-	keyBindings KeyBindings
 }
 
 func (a *app) getCurrentView() View {
@@ -139,7 +138,7 @@ func (a *app) handleKey(screen tcell.Screen, ev *tcell.EventKey) bool {
 		view.InsertRune(ev.Rune())
 		adjustViewport(view, screen)
 	} else {
-		command := a.keyBindings.GetCommandForKey(ev.Key(), ev.Modifiers())
+		command := a.settings.KeyBindings().GetCommandForKey(ev.Key(), ev.Modifiers())
 		if command != nil {
 			ret, err := command.Execute(a, a.getCurrentView(), screen, ev)
 			if err != nil {
@@ -206,6 +205,5 @@ func NewApp() (App, error) {
 		statusBar:   NewStatusBar(),
 		currentView: 0,
 		settings:    NewSettings(),
-		keyBindings: DefaultKeyBindings(),
 	}, nil
 }

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -1,21 +1,36 @@
 package app
 
+import (
+	"fmt"
+	"os"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/pelletier/go-toml/v2"
+)
+
 // Settings defines configurable editor options.
 type Settings interface {
 	// TabWidth returns the current tab width in spaces.
 	TabWidth() int
 	// SetTabWidth updates the tab width. Values <= 0 are ignored.
 	SetTabWidth(width int)
+	// KeyBindings returns the current key bindings.
+	KeyBindings() KeyBindings
+	// Load reads settings from the provided TOML file.
+	Load(filename string) error
+	// Save writes the current settings to the provided TOML file.
+	Save(filename string) error
 }
 
 // settings is the default implementation of Settings.
 type settings struct {
-	tabWidth int
+	tabWidth    int
+	keyBindings KeyBindings
 }
 
 // NewSettings creates a new Settings instance with default values.
 func NewSettings() Settings {
-	return &settings{tabWidth: 4}
+	return &settings{tabWidth: 4, keyBindings: DefaultKeyBindings()}
 }
 
 func (s *settings) TabWidth() int { return s.tabWidth }
@@ -25,4 +40,83 @@ func (s *settings) SetTabWidth(width int) {
 		return
 	}
 	s.tabWidth = width
+}
+
+func (s *settings) KeyBindings() KeyBindings { return s.keyBindings }
+
+func (s *settings) Load(filename string) error {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	var cfg struct {
+		TabWidth int `toml:"tab_width"`
+		Bindings []struct {
+			Key     int    `toml:"key"`
+			Mod     uint32 `toml:"mod"`
+			Command string `toml:"command"`
+		} `toml:"key_bindings"`
+	}
+
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return err
+	}
+
+	if cfg.TabWidth > 0 {
+		s.tabWidth = cfg.TabWidth
+	}
+
+	if len(cfg.Bindings) > 0 {
+		bindings := make([]KeyBinding, 0, len(cfg.Bindings))
+		seen := make(map[keyCombo]struct{}, len(cfg.Bindings))
+		for _, b := range cfg.Bindings {
+			kc := keyCombo{key: tcell.Key(b.Key), mod: tcell.ModMask(b.Mod)}
+			if _, ok := seen[kc]; ok {
+				return fmt.Errorf("duplicate binding for key %d mod %d", b.Key, b.Mod)
+			}
+			seen[kc] = struct{}{}
+			bindings = append(bindings, KeyBinding{
+				Key:     kc.key,
+				Mod:     kc.mod,
+				Command: GetCommand(b.Command),
+			})
+		}
+		s.keyBindings = NewKeyBindings(bindings)
+	}
+
+	return nil
+}
+
+func (s *settings) Save(filename string) error {
+	var cfg struct {
+		TabWidth int `toml:"tab_width"`
+		Bindings []struct {
+			Key     int    `toml:"key"`
+			Mod     uint32 `toml:"mod"`
+			Command string `toml:"command"`
+		} `toml:"key_bindings"`
+	}
+
+	cfg.TabWidth = s.tabWidth
+	cfg.Bindings = make([]struct {
+		Key     int    `toml:"key"`
+		Mod     uint32 `toml:"mod"`
+		Command string `toml:"command"`
+	}, 0, len(s.keyBindings.bindings))
+
+	for kc, cmd := range s.keyBindings.bindings {
+		cfg.Bindings = append(cfg.Bindings, struct {
+			Key     int    `toml:"key"`
+			Mod     uint32 `toml:"mod"`
+			Command string `toml:"command"`
+		}{Key: int(kc.key), Mod: uint32(kc.mod), Command: cmd.Name()})
+	}
+
+	data, err := toml.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filename, data, 0644)
 }

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -1,8 +1,16 @@
 package app
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
 
 func TestSettingsTabWidth(t *testing.T) {
+	commands = make(map[string]Command)
+	RegisterCommands()
 	s := NewSettings()
 	if s.TabWidth() != 4 {
 		t.Fatalf("default tab width should be 4, got %d", s.TabWidth())
@@ -14,5 +22,38 @@ func TestSettingsTabWidth(t *testing.T) {
 	s.SetTabWidth(-1)
 	if s.TabWidth() != 8 {
 		t.Fatalf("negative value should not change tab width, got %d", s.TabWidth())
+	}
+}
+
+func TestSettingsLoadDuplicateBinding(t *testing.T) {
+	commands = make(map[string]Command)
+	RegisterCommands()
+	tmp, err := os.CreateTemp("", "config_*.toml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+
+	content := "" +
+		"tab_width = 4\n" +
+		"\n" +
+		"[[key_bindings]]\n" +
+		"key = %d\n" +
+		"mod = %d\n" +
+		"command = \"exit\"\n" +
+		"\n" +
+		"[[key_bindings]]\n" +
+		"key = %d\n" +
+		"mod = %d\n" +
+		"command = \"undo\"\n"
+	data := []byte(fmt.Sprintf(content, tcell.KeyEscape, tcell.ModNone, tcell.KeyEscape, tcell.ModNone))
+	if err := os.WriteFile(tmp.Name(), data, 0644); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	s := NewSettings()
+	err = s.Load(tmp.Name())
+	if err == nil {
+		t.Fatalf("expected error for duplicate binding, got nil")
 	}
 }


### PR DESCRIPTION
## Summary
- move keyBindings from app to Settings implementation
- support key bindings in Settings
- provide TOML load and save methods for Settings
- fix tests to register commands
- remove SetKeyBindings method and detect duplicate key bindings on load

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6851dc5f75c88328bba6f99945cf7eec