### PR TITLE
Add tab bar for view switching

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -56,3 +56,32 @@ func TestHandleKeyEnter(t *testing.T) {
 		t.Fatalf("expected newline got %q", got)
 	}
 }
+
+func TestHandleMouseTabClick(t *testing.T) {
+	commands = make(map[string]Command)
+	registerCommands()
+	aInt, err := NewApp()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	a := aInt.(*app)
+	screen := tcell.NewSimulationScreen("")
+	screen.Init()
+	screen.SetSize(20, 5)
+	a.statusBar.SetScreen(screen)
+	a.tabBar.SetScreen(screen)
+
+	a.views = append(a.views, NewView("second.txt", nil))
+	for _, v := range a.views {
+		v.Resize(4, 20)
+	}
+	a.tabBar.Draw(a.views, a.currentView)
+
+	tb := a.tabBar.(*tabBar)
+	x := tb.tabPositions[1].start
+	ev := tcell.NewEventMouse(x, 0, tcell.Button1, tcell.ModNone)
+	a.handleMouse(ev)
+	if a.currentView != 1 {
+		t.Fatalf("expected current view 1 got %d", a.currentView)
+	}
+}

--- a/internal/app/tabbar.go
+++ b/internal/app/tabbar.go
@@ -1,0 +1,92 @@
+package app
+
+import "github.com/gdamore/tcell/v2"
+
+// TabBar describes the behaviour of a tab bar component.
+type TabBar interface {
+	// SetScreen sets the screen that the tab bar will draw on.
+	SetScreen(s tcell.Screen)
+	// Draw renders tabs for each view highlighting the current one.
+	Draw(views []View, current int)
+	// ViewIndexAt returns the view index for the given screen coordinates.
+	// The boolean return will be false if the coordinates are outside any tab.
+	ViewIndexAt(x, y int) (int, bool)
+}
+
+type tabPosition struct {
+	start int
+	end   int
+}
+
+type tabBar struct {
+	screen       tcell.Screen
+	tabPositions []tabPosition
+}
+
+// SetScreen sets the screen that the tab bar will draw on.
+func (tb *tabBar) SetScreen(s tcell.Screen) {
+	if s == nil {
+		panic("screen is nil")
+	}
+	tb.screen = s
+}
+
+// Draw renders the tab bar for the provided views.
+func (tb *tabBar) Draw(views []View, current int) {
+	width, _ := tb.screen.Size()
+	tb.tabPositions = make([]tabPosition, len(views))
+
+	col := 0
+	for i, v := range views {
+		title := v.Buffer().GetTitle()
+		if title == "" {
+			title = "Untitled"
+		}
+		if v.Buffer().IsDirty() {
+			title += "*"
+		}
+
+		// add spaces around title
+		text := " " + title + " "
+		start := col
+		for _, r := range text {
+			if col >= width {
+				break
+			}
+			style := tcell.StyleDefault
+			if i == current {
+				style = style.Reverse(true)
+			} else {
+				style = style.Foreground(tcell.ColorWhite)
+			}
+			tb.screen.SetContent(col, 0, r, nil, style)
+			col++
+		}
+		tb.tabPositions[i] = tabPosition{start: start, end: col}
+		if col >= width {
+			break
+		}
+	}
+	// clear remaining space
+	for ; col < width; col++ {
+		tb.screen.SetContent(col, 0, ' ', nil, tcell.StyleDefault)
+	}
+}
+
+// ViewIndexAt returns the view index for the given coordinates.
+func (tb *tabBar) ViewIndexAt(x, y int) (int, bool) {
+	if y != 0 {
+		return -1, false
+	}
+	for i, pos := range tb.tabPositions {
+		if x >= pos.start && x < pos.end {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+// NewTabBar creates a new tab bar instance.
+func NewTabBar() TabBar {
+	return &tabBar{}
+}

--- a/internal/app/tabbar_test.go
+++ b/internal/app/tabbar_test.go
@@ -1,0 +1,28 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func TestTabBarViewIndexAt(t *testing.T) {
+	tb := NewTabBar().(*tabBar)
+	screen := tcell.NewSimulationScreen("")
+	screen.Init()
+	screen.SetSize(40, 5)
+	tb.SetScreen(screen)
+	views := []View{NewView("a.txt", nil), NewView("b.txt", nil)}
+	tb.Draw(views, 0)
+
+	if idx, ok := tb.ViewIndexAt(1, 0); !ok || idx != 0 {
+		t.Fatalf("expected first tab index 0 got %d %v", idx, ok)
+	}
+	start := tb.tabPositions[1].start
+	if idx, ok := tb.ViewIndexAt(start, 0); !ok || idx != 1 {
+		t.Fatalf("expected second tab index 1 got %d %v", idx, ok)
+	}
+	if _, ok := tb.ViewIndexAt(0, 1); ok {
+		t.Fatalf("expected no tab outside top row")
+	}
+}


### PR DESCRIPTION
## Summary
- implement a TabBar component to display open views
- wire TabBar into `app` to draw at the top row
- handle mouse clicks on a tab to switch views
- test tab bar selection and app mouse handling

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68531b520bd4832889ebde527e0c9e3c