### PR TITLE
Fix selection ordering when moving before anchor

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -241,7 +241,8 @@ func (a *app) handleMouse(ev *tcell.EventMouse) {
 				aRow, aCol = oldRow, oldCol
 			}
 			row, col := view.Cursor()
-			view.SetSelections([]Selection{{StartRow: aRow, StartCol: aCol, EndRow: row, EndCol: col}})
+			sel := orderedSelection(aRow, aCol, row, col)
+			view.SetSelections([]Selection{sel})
 		} else {
 			view.ClearAnchor()
 			view.SetSelections(nil)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -176,3 +176,34 @@ func TestHandleMouseShiftSelect(t *testing.T) {
 		t.Fatalf("expected anchor cleared")
 	}
 }
+
+func TestHandleMouseShiftSelectReverse(t *testing.T) {
+	commands = make(map[string]Command)
+	registerCommands()
+	ResetApp()
+	aInt, err := NewApp()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	a := aInt.(*app)
+	screen := tcell.NewSimulationScreen("")
+	screen.Init()
+	screen.SetSize(20, 5)
+	a.statusBar.SetScreen(screen)
+
+	v := a.GetCurrentView()
+	v.Resize(4, 20)
+	v.SetCursor(0, 0)
+	v.InsertRune('a')
+	v.InsertRune('b')
+	v.InsertRune('c')
+	v.SetCursor(0, 2)
+
+	ev := tcell.NewEventMouse(0, 1, tcell.Button1, tcell.ModShift)
+	a.handleMouse(ev)
+
+	sels := v.Selections()
+	if len(sels) != 1 || sels[0].StartCol != 0 || sels[0].EndCol != 2 {
+		t.Fatalf("unexpected selection %#v", sels)
+	}
+}

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -170,7 +170,8 @@ func (c *CommandMove) Execute(app App, ev *tcell.EventKey) (bool, error) {
 			view.SetAnchor(oldRow, oldCol)
 			aRow, aCol = oldRow, oldCol
 		}
-		view.SetSelections([]Selection{{StartRow: aRow, StartCol: aCol, EndRow: row, EndCol: col}})
+		sel := orderedSelection(aRow, aCol, row, col)
+		view.SetSelections([]Selection{sel})
 	} else {
 		view.ClearAnchor()
 		view.SetSelections(nil)

--- a/internal/app/commands_test.go
+++ b/internal/app/commands_test.go
@@ -149,3 +149,22 @@ func TestCommandMoveExecuteShift(t *testing.T) {
 		t.Fatalf("expected selection cleared")
 	}
 }
+
+func TestCommandMoveExecuteShiftReverse(t *testing.T) {
+	commands = make(map[string]Command)
+	registerCommands()
+	v := NewView("", rope.NewRope("abc"))
+	d := &dummyApp{view: v}
+	ev := tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModShift)
+	c := &CommandMove{dCol: -1}
+
+	v.SetCursor(0, 2)
+	if _, err := c.Execute(d, ev); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	sels := v.Selections()
+	if len(sels) != 1 || sels[0].StartCol != 1 || sels[0].EndCol != 2 {
+		t.Fatalf("unexpected selection %#v", sels)
+	}
+}

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -87,6 +87,15 @@ type Selection struct {
 	EndCol   int
 }
 
+// orderedSelection returns a Selection with start and end points ordered such
+// that the start position is before the end position in the buffer.
+func orderedSelection(aRow, aCol, row, col int) Selection {
+	if row < aRow || (row == aRow && col < aCol) {
+		return Selection{StartRow: row, StartCol: col, EndRow: aRow, EndCol: aCol}
+	}
+	return Selection{StartRow: aRow, StartCol: aCol, EndRow: row, EndCol: col}
+}
+
 func (v *view) Buffer() Buffer {
 	return v.buffer
 }


### PR DESCRIPTION
## Summary
- ensure selections remain ordered when extending via keyboard or mouse
- add tests for reversed selections with keyboard and mouse

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c25eb0ac08328aeea5396e0f891c8