### PR TITLE
Add support for opening multiple files on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ This produces a `tked` executable in the current directory.
 
 ## Usage
 
-Run the editor with an optional file name:
+Run the editor with one or more optional file names:
 
 ```bash
-tked [file]
+tked [file...]
 ```
 
 Configuration is read from `~/.tked.toml` if it exists.

--- a/cmd/tked/main.go
+++ b/cmd/tked/main.go
@@ -32,11 +32,9 @@ func main() {
 		log.Fatalf("Failed to load settings: %v", err)
 	}
 
-	// Was a filename provided on the command line? If so, open it.
+	// Were file names provided on the command line? If so, open them all.
 	if flag.NArg() > 0 {
-		filename := flag.Arg(0)
-		err = application.OpenFile(filename)
-		if err != nil {
+		if err = openFiles(application, flag.Args()); err != nil {
 			log.Fatalf("Failed to open file: %v", err)
 		}
 	}

--- a/cmd/tked/openfiles.go
+++ b/cmd/tked/openfiles.go
@@ -1,0 +1,12 @@
+package main
+
+import "tked/internal/app"
+
+func openFiles(application app.App, filenames []string) error {
+	for _, filename := range filenames {
+		if err := application.OpenFile(filename); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/tked/openfiles_test.go
+++ b/cmd/tked/openfiles_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+	"tked/internal/app"
+)
+
+// dummyApp implements app.App for testing openFiles.
+type dummyApp struct {
+	opened []string
+}
+
+func (d *dummyApp) OpenFile(name string) error  { d.opened = append(d.opened, name); return nil }
+func (d *dummyApp) Run(tcell.Screen)            {}
+func (d *dummyApp) Settings() app.Settings      { return app.NewSettings() }
+func (d *dummyApp) LoadSettings(string) error   { return nil }
+func (d *dummyApp) GetStatusBar() app.StatusBar { return nil }
+func (d *dummyApp) GetCurrentView() app.View    { return nil }
+func (d *dummyApp) SetCurrentView(app.View)     {}
+func (d *dummyApp) Views() []app.View           { return nil }
+func (d *dummyApp) CloseView(app.View) bool     { return true }
+
+func TestOpenFiles(t *testing.T) {
+	app := &dummyApp{}
+	files := []string{"a.txt", "b.txt", "c.txt"}
+
+	if err := openFiles(app, files); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(app.opened) != len(files) {
+		t.Fatalf("expected %d files opened got %d", len(files), len(app.opened))
+	}
+	for i, f := range files {
+		if app.opened[i] != f {
+			t.Fatalf("file %d expected %s got %s", i, f, app.opened[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- handle multiple filenames on the command line
- document multi-file startup in README
- add openFiles helper and unit test

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685c2584a53c83288f8b974735fa734c