### PR TITLE
Ensure first file is active view on startup

### DIFF
--- a/cmd/tked/openfiles.go
+++ b/cmd/tked/openfiles.go
@@ -3,10 +3,17 @@ package main
 import "tked/internal/app"
 
 func openFiles(application app.App, filenames []string) error {
-	for _, filename := range filenames {
+	var firstView app.View
+	for i, filename := range filenames {
 		if err := application.OpenFile(filename); err != nil {
 			return err
 		}
+		if i == 0 {
+			firstView = application.GetCurrentView()
+		}
+	}
+	if firstView != nil {
+		application.SetCurrentView(firstView)
 	}
 	return nil
 }

--- a/cmd/tked/openfiles_test.go
+++ b/cmd/tked/openfiles_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/gdamore/tcell/v2"
@@ -37,5 +38,27 @@ func TestOpenFiles(t *testing.T) {
 		if app.opened[i] != f {
 			t.Fatalf("file %d expected %s got %s", i, f, app.opened[i])
 		}
+	}
+}
+
+func TestOpenFilesFirstFileActive(t *testing.T) {
+	app.ResetApp()
+	application, err := app.NewApp()
+	if err != nil {
+		t.Fatalf("unexpected error creating app: %v", err)
+	}
+
+	f1, _ := os.CreateTemp("", "file1*.txt")
+	defer os.Remove(f1.Name())
+	f2, _ := os.CreateTemp("", "file2*.txt")
+	defer os.Remove(f2.Name())
+
+	if err := openFiles(application, []string{f1.Name(), f2.Name()}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := application.GetCurrentView().Buffer().GetFilename()
+	if got != f1.Name() {
+		t.Fatalf("expected first file active got %s", got)
 	}
 }


### PR DESCRIPTION
## Summary
- keep first file as active view when starting with multiple files
- test that the first file remains active when multiple files are opened

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c297a0eb08328aef36bafdd907dcd