### PR TITLE
Fix selection when moving backwards

### DIFF
--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -171,6 +171,14 @@ func (c *CommandMove) Execute(app App, ev *tcell.EventKey) (bool, error) {
 			aRow, aCol = oldRow, oldCol
 		}
 		sel := orderedSelection(aRow, aCol, row, col)
+		if (c.dRow < 0 || c.dCol < 0) && (aRow < row || (aRow == row && aCol < col)) {
+			if c.dRow != 0 {
+				sel.EndRow = row + 1
+				sel.EndCol = 0
+			} else {
+				sel.EndCol = col + 1
+			}
+		}
 		view.SetSelections([]Selection{sel})
 	} else {
 		view.ClearAnchor()


### PR DESCRIPTION
## Summary
- fix selection when moving backward with shift pressed

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685c28852d588328a73f8043047a039a