### PR TITLE
Add LSP-based syntax highlighting

### DIFF
--- a/internal/app/buffer.go
+++ b/internal/app/buffer.go
@@ -275,6 +275,7 @@ func (b *buffer) notifyChange(start, end int) {
 	lspClient := lsp.GetLSP(b.GetFilename())
 	if lspClient != nil {
 		lspClient.DidChangeFull(b.GetFilename(), b.GetVersion(), b.Contents().String())
+		b.updateSemanticTokens()
 	}
 }
 
@@ -316,10 +317,12 @@ func NewBuffer(filename string, contents rope.Rope) Buffer {
 		},
 	}
 	b.SetFilename(filename)
+	registerSyntaxProperty()
 
 	lspClient := lsp.GetLSP(filename)
 	if lspClient != nil {
 		lspClient.DidOpen(filename, b.version, b.contents.rope.String())
+		b.updateSemanticTokens()
 	}
 	return b
 }

--- a/internal/app/highlight.go
+++ b/internal/app/highlight.go
@@ -1,0 +1,105 @@
+package app
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"go.lsp.dev/protocol"
+
+	"tked/internal/lsp"
+	"tked/internal/tklog"
+)
+
+// syntaxToken represents a colored range within the buffer.
+type syntaxToken struct {
+	start int
+	end   int
+	typ   protocol.SemanticTokenTypes
+}
+
+var syntaxTokensProp PropKey
+
+func registerSyntaxProperty() {
+	if syntaxTokensProp == nil {
+		syntaxTokensProp = RegisterBufferProperty()
+	}
+}
+
+var defaultSemanticTokenTypes = []protocol.SemanticTokenTypes{
+	protocol.SemanticTokenNamespace,
+	protocol.SemanticTokenType,
+	protocol.SemanticTokenClass,
+	protocol.SemanticTokenEnum,
+	protocol.SemanticTokenInterface,
+	protocol.SemanticTokenStruct,
+	protocol.SemanticTokenTypeParameter,
+	protocol.SemanticTokenParameter,
+	protocol.SemanticTokenVariable,
+	protocol.SemanticTokenProperty,
+	protocol.SemanticTokenEnumMember,
+	protocol.SemanticTokenEvent,
+	protocol.SemanticTokenFunction,
+	protocol.SemanticTokenMethod,
+	protocol.SemanticTokenMacro,
+	protocol.SemanticTokenKeyword,
+	protocol.SemanticTokenModifier,
+	protocol.SemanticTokenComment,
+	protocol.SemanticTokenString,
+	protocol.SemanticTokenNumber,
+	protocol.SemanticTokenRegexp,
+	protocol.SemanticTokenOperator,
+}
+
+func decodeSemanticTokens(b Buffer, data []uint32) []syntaxToken {
+	tokens := []syntaxToken{}
+	line := 0
+	char := 0
+	for i := 0; i+4 < len(data); i += 5 {
+		deltaLine := int(data[i])
+		deltaStart := int(data[i+1])
+		length := int(data[i+2])
+		tokenType := int(data[i+3])
+		if deltaLine == 0 {
+			char += deltaStart
+		} else {
+			line += deltaLine
+			char = deltaStart
+		}
+		startIdx := indexForPosition(b, line, char)
+		endIdx := indexForPosition(b, line, char+length)
+		if tokenType >= 0 && tokenType < len(defaultSemanticTokenTypes) {
+			tokens = append(tokens, syntaxToken{start: startIdx, end: endIdx, typ: defaultSemanticTokenTypes[tokenType]})
+		}
+	}
+	return tokens
+}
+
+var tokenColors = map[protocol.SemanticTokenTypes]tcell.Color{
+	protocol.SemanticTokenKeyword:  tcell.ColorYellow,
+	protocol.SemanticTokenString:   tcell.ColorGreen,
+	protocol.SemanticTokenComment:  tcell.ColorGray,
+	protocol.SemanticTokenNumber:   tcell.ColorLightCyan,
+	protocol.SemanticTokenFunction: tcell.ColorFuchsia,
+}
+
+func colorForToken(t protocol.SemanticTokenTypes) tcell.Color {
+	if c, ok := tokenColors[t]; ok {
+		return c
+	}
+	return tcell.ColorWhite
+}
+
+func (b *buffer) updateSemanticTokens() {
+	registerSyntaxProperty()
+	lspClient := lsp.GetLSP(b.GetFilename())
+	if lspClient == nil {
+		return
+	}
+	resp, err := lspClient.SemanticTokens(b.GetFilename())
+	if err != nil || resp == nil {
+		if err != nil {
+			tklog.Error("failed to get semantic tokens: %v", err)
+		}
+		return
+	}
+	tokens := decodeSemanticTokens(b, resp.Data)
+	b.SetProperty(syntaxTokensProp, tokens)
+}

--- a/internal/app/highlight_test.go
+++ b/internal/app/highlight_test.go
@@ -1,0 +1,34 @@
+package app
+
+import (
+	"testing"
+
+	"go.lsp.dev/protocol"
+
+	"tked/internal/rope"
+)
+
+func TestDecodeSemanticTokens(t *testing.T) {
+	commands = make(map[string]Command)
+	registerCommands()
+	ResetApp()
+	if _, err := NewApp(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	b := NewBuffer("", rope.NewRope("func main"))
+	data := []uint32{
+		0, 0, 4, uint32(15), 0, // keyword "func"
+		0, 5, 4, uint32(12), 0, // function "main"
+	}
+	tokens := decodeSemanticTokens(b, data)
+	if len(tokens) != 2 {
+		t.Fatalf("expected 2 tokens got %d", len(tokens))
+	}
+	if tokens[0].start != 0 || tokens[0].end != 4 || tokens[0].typ != protocol.SemanticTokenKeyword {
+		t.Fatalf("first token unexpected: %#v", tokens[0])
+	}
+	if tokens[1].start != 5 || tokens[1].end != 9 || tokens[1].typ != protocol.SemanticTokenFunction {
+		t.Fatalf("second token unexpected: %#v", tokens[1])
+	}
+}

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -301,6 +301,12 @@ func (v *view) Draw(screen tcell.Screen, topOffset, leftOffset int) {
 	viewHeight, viewWidth := v.Size()
 	viewTop, viewLeft := v.TopLeft()
 	selections := v.Selections()
+	tokensAny := v.buffer.GetProperty(syntaxTokensProp)
+	var tokens []syntaxToken
+	if tokensAny != nil {
+		tokens = tokensAny.([]syntaxToken)
+	}
+	tokenIdx := 0
 
 	idxRowStart, _ := v.buffer.IndexForRow(viewTop)
 	for row := viewTop; row < viewTop+viewHeight; row++ {
@@ -311,6 +317,12 @@ func (v *view) Draw(screen tcell.Screen, topOffset, leftOffset int) {
 			for col, colInfo := range colInfos {
 				if col >= viewLeft && col < viewLeft+viewWidth {
 					style := tcell.StyleDefault
+					for tokenIdx < len(tokens) && colInfo.idx >= tokens[tokenIdx].end {
+						tokenIdx++
+					}
+					if tokenIdx < len(tokens) && colInfo.idx >= tokens[tokenIdx].start && colInfo.idx < tokens[tokenIdx].end {
+						style = style.Foreground(colorForToken(tokens[tokenIdx].typ))
+					}
 					if isSelected(selections, row, col) {
 						style = style.Reverse(true)
 					}

--- a/internal/lsp/lsp.go
+++ b/internal/lsp/lsp.go
@@ -21,6 +21,9 @@ type LSPClient interface {
 
 	// TODO: Cleanup server capabilities
 	ServerTextDocumentSyncOptions() protocol.TextDocumentSyncOptions
+
+	// SemanticTokens returns semantic tokens for the given file.
+	SemanticTokens(filename string) (*protocol.SemanticTokens, error)
 }
 
 type lspClient struct {
@@ -141,6 +144,20 @@ func (lspClient) Configuration(context.Context, *protocol.ConfigurationParams) (
 }
 func (lspClient) WorkspaceFolders(context.Context) ([]protocol.WorkspaceFolder, error) {
 	return nil, nil
+}
+
+func (c *lspClient) SemanticTokens(filename string) (*protocol.SemanticTokens, error) {
+	if c.server == nil {
+		return nil, nil
+	}
+
+	tokens, err := c.server.SemanticTokensFull(context.TODO(), &protocol.SemanticTokensParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentURI(filename)},
+	})
+	if err != nil {
+		tklog.Error("LSP error on SemanticTokens %s: %v", filename, err)
+	}
+	return tokens, err
 }
 
 var startLSPClientFunc = startLSPClient


### PR DESCRIPTION
## Summary
- support semantic tokens in the LSP client
- maintain syntax token ranges per buffer
- colorize text in View.Draw based on token ranges
- add unit test for semantic token decoding

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c4124ad048328850cd1639b2ac9aa